### PR TITLE
Remove redundant paragonie/sodium_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
     "fakerphp/faker": "^1.24",
     "guzzlehttp/guzzle": "^7.9",
     "laravel/prompts": "^0.3.5",
-    "lcobucci/jwt": "^5.5",
-    "paragonie/sodium_compat": "^2.1"
+    "lcobucci/jwt": "^5.5"
   },
   "require-dev": {
     "laravel-zero/framework": "^11.36",


### PR DESCRIPTION
This package depends on `paragonie/sodium_compat: ^2.1`, but also `php: ^8.2.0`. Since `libsodium` was added in PHP 7.2, the dependency on `paragonie/sodium_compat` seems redundant?